### PR TITLE
Include tools in package without bin prefix

### DIFF
--- a/corebuild/integration/ILLink.CustomSteps/ClearInitLocals.cs
+++ b/corebuild/integration/ILLink.CustomSteps/ClearInitLocals.cs
@@ -10,8 +10,8 @@ namespace ILLink.CustomSteps
 	{
 		protected override void ProcessAssembly(AssemblyDefinition assembly)
 		{
-			foreach (ModuleDefinition module in assembly.Modules) { 
-				foreach (TypeDefinition type in module.Types) { 
+			foreach (ModuleDefinition module in assembly.Modules) {
+				foreach (TypeDefinition type in module.Types) {
 					foreach (MethodDefinition method in type.Methods) {
 						if (method.Body != null) {
 							method.Body.InitLocals = false;

--- a/corebuild/integration/ILLink.CustomSteps/ILLink.CustomSteps.csproj
+++ b/corebuild/integration/ILLink.CustomSteps/ILLink.CustomSteps.csproj
@@ -25,8 +25,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{275C1D10-168A-4AC4-8F3E-AD969F580B9C}</ProjectGuid>    
-    <RootNamespace>ILLink.CtomSteps</RootNamespace>    
+    <ProjectGuid>{275C1D10-168A-4AC4-8F3E-AD969F580B9C}</ProjectGuid>
+    <RootNamespace>ILLink.CtomSteps</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -53,13 +53,13 @@
   </Target>
   -->
   <ItemGroup>
-    <Compile Include="ClearInitLocals.cs" />    
+    <Compile Include="ClearInitLocals.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\linker\Mono.Linker.csproj">
-      <SetConfiguration Condition=" '$(Configuration)' == 'illink_Debug' ">Configuration=illink_Debug</SetConfiguration>      
-      <SetConfiguration Condition=" '$(Configuration)' == 'illink_Release' ">Configuration=illink_Release</SetConfiguration>      
+      <SetConfiguration Condition=" '$(Configuration)' == 'illink_Debug' ">Configuration=illink_Debug</SetConfiguration>
+      <SetConfiguration Condition=" '$(Configuration)' == 'illink_Release' ">Configuration=illink_Release</SetConfiguration>
       <Project>{DD28E2B1-057B-4B4D-A04D-B2EBD9E76E46}</Project>
       <Name>Mono.Cecil</Name>
     </ProjectReference>
@@ -70,6 +70,6 @@
       <SetConfiguration Condition=" '$(Configuration)' == 'illink_Release' And '$(TargetFramework)' == 'net46' ">Configuration=net_4_0_Release</SetConfiguration>
       <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
       <Name>Mono.Cecil</Name>
-    </ProjectReference>    
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -5,8 +5,8 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <RuntimeFrameworkVersion>2.0.0-beta-001509-00</RuntimeFrameworkVersion>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <OutputPath>..\bin\$(Configuration)\</OutputPath>
-    <PackageOutputPath>..\bin\nupkgs</PackageOutputPath>
+    <BaseOutputPath>../bin/</BaseOutputPath>
+    <PackageOutputPath>$(BaseOutputPath)nupkgs</PackageOutputPath>
 
     <!-- IsTool true causes the build output to be placed in the
          package's tools folder. This allows projects to reference the
@@ -43,7 +43,8 @@
          references from being marked as dependencies. -->
     <!-- TODO: Remove the custom .nuspec once the P2P PrivateAssets
          issue is fixed. -->
-    <NuspecFile>ILLink.Tasks.nuspec</NuspecFile>
+    <NuspecFileName>ILLink.Tasks.nuspec</NuspecFileName>
+    <NuspecFile>$(BaseOutputPath)$(NuspecFileName)</NuspecFile>
     <NuspecProperties>id=$(AssemblyName);authors=$(AssemblyName);description=linker tasks;</NuspecProperties>
   </PropertyGroup>
 
@@ -66,7 +67,7 @@
        Instead, we use GenerateNuspecDependsOn. We could probably also
        use BeforeTargets="GenerateNuspec". -->
   <PropertyGroup>
-    <GenerateNuspecDependsOn>SetDynamicNuspecProperties;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn>SetDynamicNuspecProperties;BinPlacePackageDeps;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
   <Target Name="SetDynamicNuspecProperties"
           DependsOnTargets="LayoutPackage">
@@ -75,11 +76,21 @@
     </PropertyGroup>
   </Target>
 
+  <!-- This target is necessary because the .nuspec includes the full
+       path of the selected dlls in the package layout. We want the
+       assets to be included in the package without the bin prefix, so
+       we place the .nuspec and the included targets alongside the
+       publish directories in the bin directory. -->
+  <Target Name="BinPlacePackageDeps">
+    <Copy SourceFiles="$(NuspecFileName)" DestinationFolder="$(BaseOutputPath)" />
+    <Copy SourceFiles="ILLink.Tasks.targets" DestinationFolder="$(BaseOutputPath)" />
+  </Target>
+
   <Target Name="LayoutPackage">
     <ItemGroup>
       <TFMsToPublish Include="$(TargetFrameworks)" />
       <ProjectsToPublish Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>TargetFramework=%(TFMsToPublish.Identity);PublishDir=bin\%(TFMsToPublish.Identity)</AdditionalProperties>
+        <AdditionalProperties>TargetFramework=%(TFMsToPublish.Identity);PublishDir=$(BaseOutputPath)%(TFMsToPublish.Identity)</AdditionalProperties>
       </ProjectsToPublish>
     </ItemGroup>
     <MSBuild Projects="@(ProjectsToPublish)" Targets="Publish" />
@@ -168,10 +179,10 @@
       <SetConfiguration>Configuration=illink_$(Configuration)</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="../../../cecil/Mono.Cecil.csproj" />
-	  
-	<ProjectReference Include="../ILLink.CustomSteps/ILLink.CustomSteps.csproj">
-	  <SetConfiguration>Configuration=illink_$(Configuration)</SetConfiguration>
-	</ProjectReference>
+
+    <ProjectReference Include="../ILLink.CustomSteps/ILLink.CustomSteps.csproj">
+      <SetConfiguration>Configuration=illink_$(Configuration)</SetConfiguration>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- Workaround for the SetConfiguration issue described above. -->

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.nuspec
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.nuspec
@@ -8,7 +8,7 @@
   </metadata>
   <files>
     <file src="ILLink.Tasks.targets" target="build" />
-    <file src="bin/netcoreapp2.0/**/*.dll" target="tools" />
-    <file src="bin/net46/**/*.dll" target="tools" />
+    <file src="netcoreapp2.0/**/*.dll" target="tools" />
+    <file src="net46/**/*.dll" target="tools" />
   </files>
 </package>

--- a/corebuild/linker.sln
+++ b/corebuild/linker.sln
@@ -58,7 +58,7 @@ Global
 		{63E6915C-7EA4-4D76-AB28-0D7191EEA626}.Release|x64.ActiveCfg = netstandard_Release|x64
 		{63E6915C-7EA4-4D76-AB28-0D7191EEA626}.Release|x64.Build.0 = netstandard_Release|x64
 		{63E6915C-7EA4-4D76-AB28-0D7191EEA626}.Release|x86.ActiveCfg = netstandard_Release|x86
-		{63E6915C-7EA4-4D76-AB28-0D7191EEA626}.Release|x86.Build.0 = netstandard_Release|x86				
+		{63E6915C-7EA4-4D76-AB28-0D7191EEA626}.Release|x86.Build.0 = netstandard_Release|x86
 		{275C1D10-168A-4AC4-8F3E-AD969F580B9C}.Debug|Any CPU.ActiveCfg = illink_Debug|Any CPU
 		{275C1D10-168A-4AC4-8F3E-AD969F580B9C}.Debug|Any CPU.Build.0 = illink_Debug|Any CPU
 		{275C1D10-168A-4AC4-8F3E-AD969F580B9C}.Debug|x64.ActiveCfg = illink_Debug|x64


### PR DESCRIPTION
This fixes the package layout when we build a NuGet package into the
corebuild/integration/bin directory.